### PR TITLE
Add Blank Menu Popup

### DIFF
--- a/frontend/src/landing/LandingPage.module.css
+++ b/frontend/src/landing/LandingPage.module.css
@@ -134,8 +134,8 @@
 }
 
 .menuPopup {
-  width: 550px;
-  height: 850px;
+  width: 400px;
+  height: 600px;
   font-size: 24px;
   font-weight: bold;
 }

--- a/frontend/src/landing/LandingPage.module.css
+++ b/frontend/src/landing/LandingPage.module.css
@@ -133,6 +133,11 @@
   height: 24px;
 }
 
+.menuPopup {
+  width: 550px;
+  height: 850px;
+}
+
 .primaryButton {
   background-color: white;
   color: #61c766;

--- a/frontend/src/landing/LandingPage.module.css
+++ b/frontend/src/landing/LandingPage.module.css
@@ -136,6 +136,8 @@
 .menuPopup {
   width: 550px;
   height: 850px;
+  font-size: 24px;
+  font-weight: bold;
 }
 
 .primaryButton {

--- a/frontend/src/landing/RestaurantTile.js
+++ b/frontend/src/landing/RestaurantTile.js
@@ -70,11 +70,11 @@ const Tiles = ({ restaurants, toBooking }) => {
                 image={index % 2 === 0 ? "./images/nandoz.png" : "./images/kcf.png"}
                 title={data.Name}
               />
-              <GridListTileBar
+            </CardActionArea>
+            <GridListTileBar
                 title={data.Name}
                 actionIcon={<MenuPopupButton restaurantName={data.Name}/>}
-              />
-            </CardActionArea>
+            />
           </Card>
         </GridListTile>
       ))}

--- a/frontend/src/landing/RestaurantTile.js
+++ b/frontend/src/landing/RestaurantTile.js
@@ -14,6 +14,9 @@ import IconButton from "@material-ui/core/IconButton";
 import style from "./LandingPage.module.css";
 import changePath from "../general/helperFunctions";
 import { getRestaurants, selectRestaurant, setMode } from "../store/restaurant/restaurantAction";
+import MenuPopupButton from "./menu/MenuPopupButton";
+import { MenuBook } from '@material-ui/icons';
+import IconButton from "@material-ui/core/IconButton";
 
 import NoRestaurants from "./NoRestaurants";
 import { resetBooking } from "../store/booking/bookingActions";
@@ -63,7 +66,7 @@ const Tiles = ({ restaurants, toBooking }) => {
     >
       {restaurants.map((data, index) => (
         <GridListTile key={data.Name} className={style.gridTile}>
-          <Card onClick={() => toBooking(data)} className={style.card}>
+          <Card className={style.card}>
             <CardActionArea>
               <CardMedia
                 style={{ height: cellHeight }}
@@ -73,12 +76,7 @@ const Tiles = ({ restaurants, toBooking }) => {
               />
               <GridListTileBar
                 title={data.Name}
-                // TODO: Link this button with the menu popup
-                actionIcon={(
-                  <IconButton className={style.menuButton}>
-                    <MenuBook className={style.menuIcon} />
-                  </IconButton>
-)}
+                actionIcon={<MenuPopupButton/>}
               />
             </CardActionArea>
           </Card>

--- a/frontend/src/landing/RestaurantTile.js
+++ b/frontend/src/landing/RestaurantTile.js
@@ -9,8 +9,6 @@ import CardMedia from "@material-ui/core/CardMedia";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { CircularProgress } from "@material-ui/core";
-import { MenuBook } from "@material-ui/icons";
-import IconButton from "@material-ui/core/IconButton";
 import style from "./LandingPage.module.css";
 import changePath from "../general/helperFunctions";
 import { getRestaurants, selectRestaurant, setMode } from "../store/restaurant/restaurantAction";
@@ -64,7 +62,7 @@ const Tiles = ({ restaurants, toBooking }) => {
     >
       {restaurants.map((data, index) => (
         <GridListTile key={data.Name} className={style.gridTile}>
-          <Card className={style.card}>
+          <Card onClick={() => toBooking(data)} className={style.card}>
             <CardActionArea>
               <CardMedia
                 style={{ height: cellHeight }}

--- a/frontend/src/landing/RestaurantTile.js
+++ b/frontend/src/landing/RestaurantTile.js
@@ -15,8 +15,6 @@ import style from "./LandingPage.module.css";
 import changePath from "../general/helperFunctions";
 import { getRestaurants, selectRestaurant, setMode } from "../store/restaurant/restaurantAction";
 import MenuPopupButton from "./menu/MenuPopupButton";
-import { MenuBook } from '@material-ui/icons';
-import IconButton from "@material-ui/core/IconButton";
 
 import NoRestaurants from "./NoRestaurants";
 import { resetBooking } from "../store/booking/bookingActions";

--- a/frontend/src/landing/RestaurantTile.js
+++ b/frontend/src/landing/RestaurantTile.js
@@ -76,7 +76,7 @@ const Tiles = ({ restaurants, toBooking }) => {
               />
               <GridListTileBar
                 title={data.Name}
-                actionIcon={<MenuPopupButton/>}
+                actionIcon={<MenuPopupButton restaurantName={data.Name}/>}
               />
             </CardActionArea>
           </Card>

--- a/frontend/src/landing/menu/MenuPopupButton.js
+++ b/frontend/src/landing/menu/MenuPopupButton.js
@@ -10,28 +10,26 @@ import Typography from '@material-ui/core/Typography';
     const { restaurantName } = props;
     const [open, setOpen] = React.useState(false);
   
-    /**
-       * Opens the popup
-       */
-    const handleClickOpen = () => {
+    // Show popup
+    const handleClickOpen = (e) => {
+      // Prevent click from propagating to restaurant card
+      e.stopPropagation();
       setOpen(true);
-    };
+    }
   
-    /**
-       * Hides the popup
-       */
+    // Hide popup
     const handleClose = () => {
       setOpen(false);
     };
   
     return (
       <>
-        <IconButton 
+        <IconButton
             className={style.menuButton}
-            onClick={handleClickOpen}> 
+            onClick={handleClickOpen}>
             <MenuBook className={style.menuIcon}/> 
         </IconButton>
-        <Dialog open={open} onClose={handleClose} >
+        <Dialog open={open} onClose={handleClose}>
             <DialogTitle className={style.menuPopup}>
               <Typography className={style.menuPopup}>
                 {restaurantName}

--- a/frontend/src/landing/menu/MenuPopupButton.js
+++ b/frontend/src/landing/menu/MenuPopupButton.js
@@ -13,7 +13,6 @@ import DialogTitle from "@material-ui/core/DialogTitle";
        * Opens the popup
        */
     const handleClickOpen = () => {
-      console.log(restaurantName + "****** handling click open ******");
       setOpen(true);
     };
   
@@ -21,21 +20,20 @@ import DialogTitle from "@material-ui/core/DialogTitle";
        * Hides the popup
        */
     const handleClose = () => {
-      console.log("****** handling close ******");
       setOpen(false);
     };
   
     return (
-      <div>
+      <>
         <IconButton 
             className={style.menuButton}
             onClick={handleClickOpen}> 
             <MenuBook className={style.menuIcon}/> 
         </IconButton>
         <Dialog open={open} onClose={handleClose} >
-            <DialogTitle>{restaurantName}</DialogTitle>
+            <DialogTitle className={style.menuPopup}>{restaurantName}</DialogTitle>
         </Dialog>
-      </div>
+      </>
     );
   };
   

--- a/frontend/src/landing/menu/MenuPopupButton.js
+++ b/frontend/src/landing/menu/MenuPopupButton.js
@@ -12,13 +12,15 @@ import Typography from '@material-ui/core/Typography';
   
     // Show popup
     const handleClickOpen = (e) => {
-      // Prevent click from propagating to restaurant card
+      // Prevent click from propagating to restaurant card and going straight to booking
       e.stopPropagation();
       setOpen(true);
     }
   
     // Hide popup
-    const handleClose = () => {
+    const handleClose = (e) => {
+      // Prevent click from propagating to restaurant card when exiting popup
+      e.stopPropagation();
       setOpen(false);
     };
   

--- a/frontend/src/landing/menu/MenuPopupButton.js
+++ b/frontend/src/landing/menu/MenuPopupButton.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { MenuBook } from '@material-ui/icons'
+import style from "../LandingPage.module.css";
+import IconButton from "@material-ui/core/IconButton";
+import Dialog from "@material-ui/core/Dialog";
+import DialogTitle from "@material-ui/core/DialogTitle";
+
+  const MenuPopupButton = (props) => {
+    const [open, setOpen] = React.useState(false);
+  
+    /**
+       * Opens the popup
+       */
+    const handleClickOpen = () => {
+      console.log("****** handling click open ******");
+      setOpen(true);
+    };
+  
+    /**
+       * Hides the popup
+       */
+    const handleClose = () => {
+      console.log("****** handling close ******");
+      setOpen(false);
+    };
+  
+    return (
+      <div>
+        <IconButton 
+            className={style.menuButton}
+            onClick={handleClickOpen}> 
+            <MenuBook className={style.menuIcon}/> 
+        </IconButton>
+        <Dialog open={open} onClose={handleClose} >
+            <DialogTitle>Example</DialogTitle>
+        </Dialog>
+      </div>
+    );
+  };
+  
+  export default MenuPopupButton;
+  

--- a/frontend/src/landing/menu/MenuPopupButton.js
+++ b/frontend/src/landing/menu/MenuPopupButton.js
@@ -4,6 +4,7 @@ import style from "../LandingPage.module.css";
 import IconButton from "@material-ui/core/IconButton";
 import Dialog from "@material-ui/core/Dialog";
 import DialogTitle from "@material-ui/core/DialogTitle";
+import Typography from '@material-ui/core/Typography';
 
   const MenuPopupButton = (props) => {
     const { restaurantName } = props;
@@ -31,7 +32,11 @@ import DialogTitle from "@material-ui/core/DialogTitle";
             <MenuBook className={style.menuIcon}/> 
         </IconButton>
         <Dialog open={open} onClose={handleClose} >
-            <DialogTitle className={style.menuPopup}>{restaurantName}</DialogTitle>
+            <DialogTitle className={style.menuPopup}>
+              <Typography className={style.menuPopup}>
+                {restaurantName}
+              </Typography>
+            </DialogTitle>
         </Dialog>
       </>
     );

--- a/frontend/src/landing/menu/MenuPopupButton.js
+++ b/frontend/src/landing/menu/MenuPopupButton.js
@@ -6,13 +6,14 @@ import Dialog from "@material-ui/core/Dialog";
 import DialogTitle from "@material-ui/core/DialogTitle";
 
   const MenuPopupButton = (props) => {
+    const { restaurantName } = props;
     const [open, setOpen] = React.useState(false);
   
     /**
        * Opens the popup
        */
     const handleClickOpen = () => {
-      console.log("****** handling click open ******");
+      console.log(restaurantName + "****** handling click open ******");
       setOpen(true);
     };
   
@@ -32,7 +33,7 @@ import DialogTitle from "@material-ui/core/DialogTitle";
             <MenuBook className={style.menuIcon}/> 
         </IconButton>
         <Dialog open={open} onClose={handleClose} >
-            <DialogTitle>Example</DialogTitle>
+            <DialogTitle>{restaurantName}</DialogTitle>
         </Dialog>
       </div>
     );


### PR DESCRIPTION
## Link to Issue Number
#186 

## Description
This PR adds a menu popup that appears when clicking the menu icon on restaurant cards. Currently, this just shows the title of the restaurant that has been clicked on, as the rest of the functionality of this feature is covered in other issues. 

The menu popup appears as below:
![image](https://user-images.githubusercontent.com/26205812/79536763-e87ab780-80d4-11ea-9fcf-a2706c512198.png)

## Checklist
- [x] All feature request A/C have been met OR the bug has been fixed
- [x] I ran all necessary tests and they pass
- [x] I rebased upstream/master onto my working branch before opening this PR
- [x] I have named my PR something sensible
- [x] I have included the issue number above
- [x] I have assigned at least two people to review my changes

## Other Notes
The size of the menu popup is not consistent with the specification provided on the [hi-fi](https://github.com/SE701ProjectGroup4/git-brunching/wiki/Menu-Pop-up-Hi-Fi-Prototype) as this did not fit on my screen. Sizing has been added as custom styling so can easily be modified if desired. 
