### PR TITLE
Get restaurant table data in smaller batches

### DIFF
--- a/backend/routes/restaurant.js
+++ b/backend/routes/restaurant.js
@@ -101,6 +101,8 @@ router.get('/:restaurantID/openhours', async (req, res) => {
  *     responses:
  *       200:
  *         description: Returns all restaurant objects
+ *       400:
+ *         description: At least one of the parameters was not supplied correctly.
  */
 router.get('/', (req, res) => {
   const { batch, limit } = req.query;
@@ -247,16 +249,18 @@ router.get('/:restaurantID/capacity', (req, res) => {
     res.status(400).json({ error: 'GET /restaurant/{id}/openhours invocation error: {id} must be an int' });
     return;
   }
-  
+
   connection.query(
-  'SELECT MIN(MinGuests) as minimum, MAX(MaxGuests) as maximum FROM restaurant_db.table as t WHERE t.RestaurantID = ?;', [restaurantID], 
-  (error, results) => {
+    'SELECT MIN(MinGuests) as minimum, MAX(MaxGuests) as maximum FROM restaurant_db.table as t WHERE t.RestaurantID = ?;',
+    [restaurantID],
+    (error, results) => {
       if (error) {
         res.status(400).json({ error });
         return;
       }
       res.json(results);
-    });
- });
+    }
+  );
+});
 
 export default router;

--- a/backend/routes/restaurant.js
+++ b/backend/routes/restaurant.js
@@ -84,7 +84,7 @@ router.get('/:restaurantID/openhours', async (req, res) => {
  *
  * /restaurant:
  *   get:
- *     description: Fetch all restaurant objects from the database
+ *     description: Fetch all or a batch of restaurant objects from the database in one API call.
  *     produces:
  *       - application/json
  *     parameters:


### PR DESCRIPTION
## Link to Issue Number
Closes #208 

## Description
Adds ability to retrieve restaurant table data in smaller batches in the backend using query values.
Includes returning 400 requests with appropriate error message for invalid query values.
Swagger UI also supports the new `GET /restaurant/` functionality.

## Checklist
- [x] All feature request A/C have been met OR the bug has been fixed
- [x] I ran all necessary tests and they pass
- [x] I rebased upstream/master onto my working branch before opening this PR
- [x] I have named my PR something sensible
- [x] I have included the issue number above
- [x] I have assigned at least two people to review my changes


## Other Notes
The two query parameters are `limit` (maximum number of result per batch) and `batch` (index of batch) and both are to be integers.
Next batch can be obtained by incrementing the value of `batch`.
The original functionality of `GET /restaurant/` can be used by not supplying values to any query parameters.
