### PR TITLE
Fixed incorrect reservation dates

### DIFF
--- a/backend/routes/reservation.js
+++ b/backend/routes/reservation.js
@@ -77,6 +77,10 @@ router.get('/', async (req, res) => {
     res.status(400).json({ error });
     return;
   }
+  //Convert date from UTC to local time
+  result.forEach(element => {
+    element.Date.setUTCMinutes(element.Date.getMinutes() - element.Date.getTimezoneOffset())
+  });
   res.json({ result });
 });
 
@@ -117,6 +121,10 @@ router.get('/restaurant', async (req, res) => {
     res.status(400).json({ error });
     return;
   }
+  //Convert dates from UTC to local time
+  result.forEach(element => {
+    element.Date.setUTCMinutes(element.Date.getMinutes() - element.Date.getTimezoneOffset())
+  });
   res.json({ result });
 });
 

--- a/frontend/src/restaurant/RestaurantViewBookingPage.js
+++ b/frontend/src/restaurant/RestaurantViewBookingPage.js
@@ -67,7 +67,7 @@ const RestaurantViewBookingPage = (props) => {
         <span className={style.bookingCode}>{`Booking Code: ${id}`}</span>
       </div>
       <div>
-        <span className={style.date}>{`${date}`}</span>
+        <span className={style.date}>{`${date.substring(0,10)}`}</span>
         <span className={style.time}>{time}</span>
       </div>
       <div className={style.userDetails}>


### PR DESCRIPTION
## Link to Issue Number
Closes #148


## Description
Dates of reservations are now displayed in the correct timezone rather than UTC, fixing issues that this was causing with editing & deleting reservations. Times are also now displayed nicely on the view all reservations page.


## Checklist
- [x] All feature request A/C have been met OR the bug has been fixed
- [ ] I ran all necessary tests and they pass
- [x] I rebased upstream/master onto my working branch before opening this PR
- [x] I have named my PR something sensible
- [x] I have included the issue number above
- [x] I have assigned at least two people to review my changes


## Other Notes
These changes can be viewed from the reservations screen as the edit reservation functionality currently seems broken
