### PR TITLE
Feature/196 support different db names

### DIFF
--- a/backend/restaurant_db.sql
+++ b/backend/restaurant_db.sql
@@ -23,6 +23,8 @@ SET @@SESSION.SQL_LOG_BIN= 0;
 -- GTID state at the beginning of the backup 
 --
 
+SET @@GLOBAL.GTID_PURGED=/*!80000 '+'*/ 'e9f8d073-747f-11ea-9b62-42010a800373:1-280935';
+
 --
 -- Table structure for table `HOURS`
 --

--- a/backend/restaurant_db.sql
+++ b/backend/restaurant_db.sql
@@ -23,8 +23,6 @@ SET @@SESSION.SQL_LOG_BIN= 0;
 -- GTID state at the beginning of the backup 
 --
 
-SET @@GLOBAL.GTID_PURGED=/*!80000 '+'*/ 'e9f8d073-747f-11ea-9b62-42010a800373:1-280935';
-
 --
 -- Table structure for table `HOURS`
 --

--- a/backend/routes/reservation.js
+++ b/backend/routes/reservation.js
@@ -418,7 +418,7 @@ router.get('/available', async (req, res) => {
 
   const { error, result } = await connection.asyncQuery(
     'SELECT t.ID ' +
-    'FROM restaurant_db.TABLE t ' +
+    'FROM `TABLE` t ' +
     'WHERE t.RestaurantID = ? AND t.maxGuests >= ? AND t.minGuests <= ? AND NOT EXISTS ( SELECT * ' +
                                                                         'FROM RESERVATION r ' +
                                                                         'WHERE t.RestaurantID = r.RestaurantID AND ' +

--- a/backend/routes/restaurant.js
+++ b/backend/routes/restaurant.js
@@ -218,7 +218,7 @@ router.get('/:restaurantID/capacity', (req, res) => {
   }
   
   connection.query(
-  'SELECT MIN(MinGuests) as minimum, MAX(MaxGuests) as maximum FROM restaurant_db.TABLE as t WHERE t.RestaurantID = ?;', [restaurantID], 
+  'SELECT MIN(MinGuests) as minimum, MAX(MaxGuests) as maximum FROM `TABLE` as t WHERE t.RestaurantID = ?;', [restaurantID], 
   (error, results) => {
       if (error) {
         res.status(400).json({ error });

--- a/backend/routes/table.js
+++ b/backend/routes/table.js
@@ -88,9 +88,9 @@ router.get('/free', async (req, res) => {
       connection
         .asyncQuery(
           'SELECT t.ID ' +
-          'FROM restaurant_db.TABLE t ' +
+          'FROM `TABLE` t ' +
           'WHERE t.RestaurantID = ? AND t.maxGuests >= ? AND t.minGuests <= ? AND NOT EXISTS ( SELECT * ' +
-                                                                                  'FROM restaurant_db.RESERVATION r ' +
+                                                                                  'FROM RESERVATION r ' +
                                                                                   'WHERE t.RestaurantID = r.RestaurantID AND ' +
                                                                                   't.ID = r.TableID AND ' +
                                                                                   'r.Date = ? AND ' +

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -88,7 +88,7 @@ router.get('/:userID', async (req, res) => {
   }
 
   const { error, result } = await connection.asyncQuery(
-    'SELECT * FROM restaurant_db.USER WHERE ID = ? ',
+    'SELECT * FROM USER WHERE ID = ? ',
     [userID]
   );
 

--- a/backend/tests/reservation/getAllForRestaurant.js
+++ b/backend/tests/reservation/getAllForRestaurant.js
@@ -10,16 +10,16 @@ before(async () => {
   // Setup the database before any tests in this file run.
   const errors = [];
   await connection
-    .asyncQuery('INSERT INTO restaurant_db.RESTAURANT VALUES (1, "Example restaurant0");')
+    .asyncQuery('INSERT INTO RESTAURANT VALUES (1, "Example restaurant0");')
     .then(({ error }) => error && errors.push(error));
 
   await connection
-    .asyncQuery(`INSERT INTO restaurant_db.TABLE VALUES (1, 1, 1, 6);`)
+    .asyncQuery(`INSERT INTO \`TABLE\` VALUES (1, 1, 1, 6);`)
     .then(({ error }) => error && errors.push(error));
 
   await connection
     .asyncQuery(
-      `INSERT INTO restaurant_db.USER VALUES (1, "First name", "Last name", "09 123,456", "example@email.com");`
+      `INSERT INTO USER VALUES (1, "First name", "Last name", "09 123,456", "example@email.com");`
     )
     .then(({ error }) => error && errors.push(error));
   assert.strictEqual(errors.length, 0, 'Expected no errors in initial setup');
@@ -48,7 +48,7 @@ describe('GET reservations/', () => {
   it('2. should return an array of reservations when the restaurant only has one reservation', async function () {
     // await connection
     //   .asyncQuery(
-    //     `INSERT INTO restaurant_db.RESERVATION (ID, Date, Time, Notes, NumberOfGuests, TableID, RestaurantID, UserID)
+    //     `INSERT INTO RESERVATION (ID, Date, Time, Notes, NumberOfGuests, TableID, RestaurantID, UserID)
     // VALUES (1, '2020-03-14', '11:30:00', '', '1', '1', '1', '1');`
     //   )
     //   .then(({ error }) => {
@@ -92,7 +92,7 @@ describe('GET reservations/', () => {
   it('3. should return an array of reservations when the restaurant has multiple reservations', async function () {
     // await connection
     //   .asyncQuery(
-    //     `INSERT INTO restaurant_db.RESERVATION (ID, Date, Time, Notes, NumberOfGuests, TableID, RestaurantID, UserID)
+    //     `INSERT INTO RESERVATION (ID, Date, Time, Notes, NumberOfGuests, TableID, RestaurantID, UserID)
     // VALUES (2, '2020-03-14', '11:30:00', '', '1', '1', '1', '1');`
     //   )
     //   .then(({ error }) => {
@@ -101,7 +101,7 @@ describe('GET reservations/', () => {
 
     // await connection
     //   .asyncQuery(
-    //     `INSERT INTO restaurant_db.RESERVATION (ID, Date, Time, Notes, NumberOfGuests, TableID, RestaurantID, UserID)
+    //     `INSERT INTO RESERVATION (ID, Date, Time, Notes, NumberOfGuests, TableID, RestaurantID, UserID)
     // VALUES (3, '2020-03-14', '11:30:00', '', '1', '1', '1', '1');`
     //   )
     //   .then(({ error }) => {

--- a/backend/tests/reviews/getAllForRestaurant.js
+++ b/backend/tests/reviews/getAllForRestaurant.js
@@ -10,7 +10,7 @@
 //   // Setup the database before any tests in this file run.
 //   const errors = [];
 //   await connection
-//     .asyncQuery('INSERT INTO restaurant_db.RESTAURANT VALUES (6, "Example restaurant1");')
+//     .asyncQuery('INSERT INTO RESTAURANT VALUES (6, "Example restaurant1");')
 //     .then(({ error }) => error && errors.push(error));
 //   await connection;
 
@@ -38,7 +38,7 @@
 //   // Test that the API is able to return the correct result when there is only one review for the desired restaurant.
 //   it('2. should return an array of reviews when the restaurant only has one review', async function () {
 //     await connection
-//       .asyncQuery(`INSERT INTO restaurant_db.REVIEW VALUES (1, "Bryan", 1, "This place sucks");`)
+//       .asyncQuery(`INSERT INTO REVIEW VALUES (1, "Bryan", 1, "This place sucks");`)
 //       .then(({ error }) => {
 //         assert.isUndefined(error, 'Expected no errors when adding items to database');
 //       });
@@ -74,13 +74,13 @@
 //   // Test that the API is able to return the correct result when there are multiple reviews for the desired restaurant.
 //   it('3. should return an array of reviews when the restaurant has multiple reviews', async function () {
 //     await connection
-//       .asyncQuery(`INSERT INTO restaurant_db.REVIEW VALUES (1, "Bryan", 1, "This place sucks");`)
+//       .asyncQuery(`INSERT INTO REVIEW VALUES (1, "Bryan", 1, "This place sucks");`)
 //       .then(({ error }) => {
 //         assert.isUndefined(error, 'Expected no errors when adding items to database');
 //       });
 
 //     await connection
-//       .asyncQuery(`INSERT INTO restaurant_db.REVIEW VALUES (2, "Richard", 1, "OMG best place ever");`)
+//       .asyncQuery(`INSERT INTO REVIEW VALUES (2, "Richard", 1, "OMG best place ever");`)
 //       .then(({ error }) => {
 //         assert.isUndefined(error, 'Expected no errors when adding items to database');
 //       });


### PR DESCRIPTION
## Link to Issue Number
#196  

## Description
Because there's a table called 'table', some SQL queries refer to 'restaurant_db.table' I have removed these references (and used the `table` literal string) because they force the operator to use restaurant_db as the database name.


## Checklist
- [x] All feature request A/C have been met OR the bug has been fixed
- [x] I ran all necessary tests and they pass
- [x] I rebased upstream/master onto my working branch before opening this PR
- [x] I have named my PR something sensible
- [x] I have included the issue number above
- [x] I have assigned at least two people to review my changes


## Other Notes
If you want to test this works, rename your database to something else (and change the env var). 
