### PR TITLE
Display multi-page menus

### DIFF
--- a/backend/restaurant_db.sql
+++ b/backend/restaurant_db.sql
@@ -69,7 +69,7 @@ CREATE TABLE `MENU` (
 
 LOCK TABLES `MENU` WRITE;
 /*!40000 ALTER TABLE `MENU` DISABLE KEYS */;
-INSERT INTO `MENU` VALUES (1,1,'https://user-images.githubusercontent.com/27871855/79630073-91dbaf00-81a2-11ea-89eb-ce3c6015a26e.jpg',650,633),(2,1,'https://user-images.githubusercontent.com/27871855/79630073-91dbaf00-81a2-11ea-89eb-ce3c6015a26e.jpg',650,633),(3,1,'https://user-images.githubusercontent.com/27871855/79630073-91dbaf00-81a2-11ea-89eb-ce3c6015a26e.jpg',650,633),(4,2,'https://user-images.githubusercontent.com/27871855/79630073-91dbaf00-81a2-11ea-89eb-ce3c6015a26e.jpg',650,633),(5,3,'https://user-images.githubusercontent.com/27871855/79630073-91dbaf00-81a2-11ea-89eb-ce3c6015a26e.jpg',650,633);
+INSERT INTO `MENU` VALUES (1,1,'https://user-images.githubusercontent.com/27871855/79630073-91dbaf00-81a2-11ea-89eb-ce3c6015a26e.jpg',650,633),(2,1,'https://user-images.githubusercontent.com/40927123/80356666-df0bff00-88cd-11ea-81f8-7fd9f231b587.png',650,633),(3,1,'https://user-images.githubusercontent.com/27871855/79630073-91dbaf00-81a2-11ea-89eb-ce3c6015a26e.jpg',650,633),(4,2,'https://user-images.githubusercontent.com/27871855/79630073-91dbaf00-81a2-11ea-89eb-ce3c6015a26e.jpg',650,633),(5,3,'https://user-images.githubusercontent.com/27871855/79630073-91dbaf00-81a2-11ea-89eb-ce3c6015a26e.jpg',650,633);
 /*!40000 ALTER TABLE `MENU` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7345,13 +7345,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7369,8 +7367,7 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
@@ -7502,20 +7499,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7532,7 +7526,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7624,7 +7617,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7700,8 +7692,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7793,8 +7784,7 @@
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -8486,6 +8476,16 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8512,6 +8512,11 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -11168,6 +11173,20 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.6.tgz",
       "integrity": "sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw=="
     },
+    "react-image-gallery": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-image-gallery/-/react-image-gallery-1.0.7.tgz",
+      "integrity": "sha512-4M8HdzTmH13kFNXezcsL6gWT460HUUqlKoAN0XUZMFSQIXdx7eGSj7dkjQlij2UJVZ6LGpjXcEVR7YzJ1Gz9Sg==",
+      "requires": {
+        "clsx": "^1.0.4",
+        "lodash.debounce": "^4.0.8",
+        "lodash.isequal": "^4.5.0",
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.5.8",
+        "react-swipeable": "^5.2.0",
+        "resize-observer-polyfill": "^1.5.0"
+      }
+    },
     "react-is": {
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
@@ -11447,6 +11466,14 @@
             "read-pkg": "^2.0.0"
           }
         }
+      }
+    },
+    "react-swipeable": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-5.5.1.tgz",
+      "integrity": "sha512-EQObuU3Qg3JdX3WxOn5reZvOSCpU4fwpUAs+NlXSN3y+qtsO2r8VGkVnOQzmByt3BSYj9EWYdUOUfi7vaMdZZw==",
+      "requires": {
+        "prop-types": "^15.6.2"
       }
     },
     "react-transition-group": {
@@ -11755,6 +11782,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.15.0",
@@ -14510,8 +14542,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14535,7 +14566,6 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14548,8 +14578,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -14558,8 +14587,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14662,8 +14690,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14673,7 +14700,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14686,20 +14712,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14716,7 +14739,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -14797,8 +14819,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14808,7 +14829,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14884,8 +14904,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14915,7 +14934,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14933,7 +14951,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14972,13 +14989,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "history": "^4.10.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-image-gallery": "^1.0.7",
     "react-redux": "^7.2.0",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",

--- a/frontend/src/landing/LandingPage.module.css
+++ b/frontend/src/landing/LandingPage.module.css
@@ -179,7 +179,9 @@
   padding: 15px 20px;
   width: 500px;
   height: 500px;
-  align-self: center;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .noMenuImage {

--- a/frontend/src/landing/RestaurantTile.js
+++ b/frontend/src/landing/RestaurantTile.js
@@ -116,10 +116,8 @@ const Tiles = ({
                 title={data.Name}
                 actionIcon={
                   <div>
-                    <MenuPopupButton restaurant={data} toBooking={toBooking}>
-                    </MenuPopupButton> 
-                    <ReviewPopupButton restaurant={data}>
-                    </ReviewPopupButton> 
+                    <MenuPopupButton restaurant={data} toBooking={toBooking}/>
+                    <ReviewPopupButton restaurant={data}/>
                   </div>                 
                 }
                 />

--- a/frontend/src/landing/menu/CustomGalleryColours.css
+++ b/frontend/src/landing/menu/CustomGalleryColours.css
@@ -1,0 +1,19 @@
+button.image-gallery-icon:hover {
+    color: #61c766;
+}
+
+button.image-gallery-icon {
+    scale: 0.6 0.8;
+}
+
+.image-gallery-bullets .image-gallery-bullet:focus, .image-gallery-bullets .image-gallery-bullet:hover {
+    background: #61c766;
+}
+
+.image-gallery-bullets .image-gallery-bullet {
+    background-color:#c5c5c5;
+}
+
+.image-gallery-bullets .image-gallery-bullet.active {
+    background: #61c766;
+  }

--- a/frontend/src/landing/menu/Menu.js
+++ b/frontend/src/landing/menu/Menu.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ImageGallery from 'react-image-gallery';
 import "react-image-gallery/styles/css/image-gallery.css";
+import "./CustomGalleryColours.css";
 import style from "../LandingPage.module.css";
 import { ReactComponent as NoMenu } from "../../general/NoMenuImage.svg";
 
@@ -34,9 +35,9 @@ const Menu = (props) => {
       items={menus.map(menu => ({ original: menu.Link }))}
       showPlayButton={false}
       showThumbnails={false}
+      showFullscreenButton={false}
       infinite={false}
       showBullets={true}
-      additionalClass={"menuGallery"}
     />
   );
 }

--- a/frontend/src/landing/menu/Menu.js
+++ b/frontend/src/landing/menu/Menu.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import ImageGallery from 'react-image-gallery';
+import "react-image-gallery/styles/css/image-gallery.css";
 import style from "../LandingPage.module.css";
 import { ReactComponent as NoMenu } from "../../general/NoMenuImage.svg";
 
@@ -27,13 +29,15 @@ const Menu = (props) => {
     );
   }
 
-  //TODO
   return (
-    <div>
-      <img className={style.menuImage}
-        src={menus[0].Link}
-        alt="Menu Page" />
-    </div>
+    <ImageGallery
+      items={menus.map(menu => ({ original: menu.Link }))}
+      showPlayButton={false}
+      showThumbnails={false}
+      infinite={false}
+      showBullets={true}
+      additionalClass={"menuGallery"}
+    />
   );
 }
 

--- a/frontend/src/landing/menu/Menu.js
+++ b/frontend/src/landing/menu/Menu.js
@@ -2,30 +2,39 @@ import React from 'react';
 import style from "../LandingPage.module.css";
 import { ReactComponent as NoMenu } from "../../general/NoMenuImage.svg";
 
-
 const Menu = (props) => {
+  const { menus, isLoading } = props;
 
-    const { menus, isLoading } = props;
+  if (isLoading) {
+    return (
+      <div>Loading...</div>
+    );
+  }
 
-    if (isLoading == true) {
-      return (<div>Loading...</div>);
-    }
-    else if ( !isLoading && menus.length == 0) {
-        return(
-            <NoMenu className={style.noMenuImage}></NoMenu>
-        );
-    }
+  if (menus.length === 0) {
+    return (
+      <NoMenu className={style.noMenuImage} />
+    );
+  }
 
-    else {
-      return (
-        <div>
-          <img className={style.menuImage}
+  if (menus.length === 1) {
+    return (
+      <div>
+        <img className={style.menuImage}
           src={menus[0].Link}
-          alt="new"/>
-        </div>
+          alt="Single Menu Page" />
+      </div>
+    );
+  }
 
-      );
-    } 
-  }  
+  //TODO
+  return (
+    <div>
+      <img className={style.menuImage}
+        src={menus[0].Link}
+        alt="Menu Page" />
+    </div>
+  );
+}
 
-  export default Menu;
+export default Menu;

--- a/frontend/src/landing/menu/MenuPopupButton.js
+++ b/frontend/src/landing/menu/MenuPopupButton.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { MenuBook, Store } from '@material-ui/icons'
+import { MenuBook } from '@material-ui/icons'
 import style from "../LandingPage.module.css";
 import IconButton from "@material-ui/core/IconButton";
 import Dialog from "@material-ui/core/Dialog";
@@ -52,7 +52,7 @@ import Button from "@material-ui/core/Button";
               </Typography>
             </DialogTitle>
             <DialogContent>
-              <Menu menus={menus} isLoading={isLoading}></Menu>
+              <Menu menus={menus} isLoading={isLoading}/>
             </DialogContent>
             <div className={style.menuButtonsContainer}>
                 <Button variant="outlined" className={style.primaryButton} onClick={handleClose}>Cancel</Button>

--- a/frontend/src/landing/menu/MenuPopupButton.js
+++ b/frontend/src/landing/menu/MenuPopupButton.js
@@ -44,7 +44,7 @@ import Button from "@material-ui/core/Button";
             onClick={(e) => handleClickOpen(e)}>
             <MenuBook className={style.menuIcon}/> 
         </IconButton>
-        <Dialog fullWidth="true" maxWidth="sm"
+        <Dialog fullWidth={true} maxWidth="sm"
         open={open} onClose={(e) => handleClose(e)} onClick={handlePopupClick}>
             <DialogTitle>
               <Typography className={style.menuPopupTitle}>


### PR DESCRIPTION

## Link to Issue Number
Closes #182 

## Description
Users can now view multiple menus/images when they click the view menu button.

Also fixed some warnings in related areas of code.

You may notice the dialog grows to fit the currently displayed image, but it really shouldn't matter because the same restaurant would be uploading similar sized images anyway.
<details>
  <summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/40927123/80358028-eb915700-88cf-11ea-999a-c449c39849fe.png)
</details>


## Checklist
- [x] All feature request A/C have been met OR the bug has been fixed
- [ ] I ran all necessary tests and they pass
- [x] I rebased upstream/master onto my working branch before opening this PR
- [x] I have named my PR something sensible
- [x] I have included the issue number above
- [x] I have assigned at least two people to review my changes


## Other Notes
Don't forget to `npm i` the frontend folder and re-import the test database if you're reviewing
<details>
  <summary>Ignore this, just uploading another menu to use</summary>

![White-Black-Pizza-Italian-Stripes-Restaurant-Menu](https://user-images.githubusercontent.com/40927123/80356666-df0bff00-88cd-11ea-81f8-7fd9f231b587.png)
</details>
